### PR TITLE
fix(piped/frontend): make nginx entrypoint actually do something

### DIFF
--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/TeamPiped/piped-proxy
 keywords:
   - streaming
-version: 2.7.0
+version: 2.7.1
 appVersion: latest
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -26,5 +26,5 @@ dependencies:
     condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Upgraded `postgresql` chart dependency to version 12.6.0
+    - kind: fixed
+      description: Made frontend nginx entrypoint run docker-entrypoint.d scripts

--- a/charts/apps/piped/values.yaml
+++ b/charts/apps/piped/values.yaml
@@ -46,7 +46,7 @@ frontend:
   command: "/bin/ash"
   args:
     - -c
-    - "sed -i s/pipedapi.kavin.rocks/$BACKEND_HOSTNAME/g /usr/share/nginx/html/assets/* && /docker-entrypoint.sh && nginx -g 'daemon off;'"
+    - "sed -i s/pipedapi.kavin.rocks/$BACKEND_HOSTNAME/g /usr/share/nginx/html/assets/* && /docker-entrypoint.sh nginx -g 'daemon off;'"
 
   # resources:
   #  requests:


### PR DESCRIPTION
It does nothing if 1st argument is not nginx and just execs the arguments: https://github.com/nginxinc/docker-nginx/blob/master/entrypoint/docker-entrypoint.sh#L12