### PR TITLE
chore(backend): Fix the configmap generation for databases.

### DIFF
--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -13,7 +13,7 @@ version: 2.8.0
 appVersion: latest
 kubeVersion: ">=1.22.0-0"
 maintainers:
-  - name: samip5 # Skyler Mäntysaari
+  - name: samip5  # Skyler Mäntysaari
     email: samip5@users.noreply.github.com
     url: https://github.com/samip5
 dependencies:

--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -13,7 +13,7 @@ version: 2.8.0
 appVersion: latest
 kubeVersion: ">=1.22.0-0"
 maintainers:
-  - name: Skyler Mäntysaari
+  - name: samip5 # Skyler Mäntysaari
     email: samip5@users.noreply.github.com
     url: https://github.com/samip5
 dependencies:

--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/TeamPiped/piped-proxy
 keywords:
   - streaming
-version: 2.7.1
+version: 2.8.0
 appVersion: latest
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -26,5 +26,5 @@ dependencies:
     condition: postgresql.enabled
 annotations:
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: Made frontend nginx entrypoint run docker-entrypoint.d scripts
+    - kind: changed
+      description: Backend configmap was changed to not require driver_class nor dialect but rather specify them by default.

--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -28,3 +28,5 @@ annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: Backend configmap was changed to not require driver_class nor dialect but rather specify them by default.
+    - kind: fixed
+      description: Backend configmap wasn't getting feed retention correctly passed.

--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -3,6 +3,7 @@ apiVersion: v2
 description: Piped is an alternative privacy-friendly YouTube frontend which is efficient by design.
 name: piped
 home: https://github.com/TeamPiped/Piped-Kubernetes
+icon: https://raw.githubusercontent.com/TeamPiped/Piped/master/public/img/icons/logo.svg
 sources:
   - https://github.com/TeamPiped/Piped
   - https://github.com/TeamPiped/Piped-Backend

--- a/charts/apps/piped/README.md
+++ b/charts/apps/piped/README.md
@@ -172,7 +172,7 @@ N/A
 
 #### Fixed
 
-N/A
+* Backend configmap wasn't getting feed retention correctly passed.
 
 ## Support
 

--- a/charts/apps/piped/README.md
+++ b/charts/apps/piped/README.md
@@ -1,6 +1,6 @@
 # piped
 
-![Version: 2.6.2](https://img.shields.io/badge/Version-2.6.2-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Piped is an alternative privacy-friendly YouTube frontend which is efficient by design.
 
@@ -21,7 +21,7 @@ Kubernetes: `>=1.22.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://bjw-s.github.io/helm-charts | common | 1.5.1 |
-| https://charts.bitnami.com/bitnami | postgresql | 12.5.6 |
+| https://charts.bitnami.com/bitnami | postgresql | 12.6.0 |
 
 ## TL;DR
 
@@ -91,7 +91,7 @@ helm install piped TeamPiped/piped -f values.yaml
 | backend.service.main.type | string | `"ClusterIP"` |  |
 | controller.enabled | bool | `false` | enable the controller. |
 | frontend.args[0] | string | `"-c"` |  |
-| frontend.args[1] | string | `"sed -i s/pipedapi.kavin.rocks/$BACKEND_HOSTNAME/g /usr/share/nginx/html/assets/* && /docker-entrypoint.sh && nginx -g 'daemon off;'"` |  |
+| frontend.args[1] | string | `"sed -i s/pipedapi.kavin.rocks/$BACKEND_HOSTNAME/g /usr/share/nginx/html/assets/* && /docker-entrypoint.sh nginx -g 'daemon off;'"` |  |
 | frontend.command | string | `"/bin/ash"` |   BACKEND_HOSTNAME: pipedapi.example.org |
 | frontend.enabled | bool | `true` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | image pull policy |
@@ -160,7 +160,7 @@ helm install piped TeamPiped/piped -f values.yaml
 
 ## Changelog
 
-### Version 2.6.2
+### Version 2.8.0
 
 #### Added
 
@@ -168,11 +168,11 @@ N/A
 
 #### Changed
 
-N/A
+* Backend configmap was changed to not require driver_class nor dialect but rather specify them by default.
 
 #### Fixed
 
-* ytproxy ingress, GH issue 29
+N/A
 
 ## Support
 

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -78,4 +78,8 @@ data:
     {{- else }}
      {{- fail "Unable to figure out database configuration for backend configmap."}}
     {{- end }}
+    {{- if .Values.backend.config.SENTRY_DNS }}
+    SENTRY_DSN: {{.Values.backend.SENTRY_DNS }}
+    {{- else }}
     SENTRY_DSN:
+    {{- end }}

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -56,10 +56,14 @@ data:
     FEED_RETENTION: {{ .Values.backend.config.DISABLE_REGISTRATION | int | default 30 }}
     {{- if and (.Values.backend.config.database) (not .Values.postgresql.enabled) }}
     hibernate.connection.url: {{.Values.backend.config.database.connection_url }}
+    {{- else if and (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect)}}
     hibernate.connection.driver_class: {{.Values.backend.config.database.driver_class }}
     hibernate.dialect: {{.Values.backend.config.database.dialect }}
     hibernate.connection.username: {{.Values.backend.config.database.username }}
     hibernate.connection.password: {{.Values.backend.config.database.password }}
+    {{- else if (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
+    hibernate.connection.driver_class: org.postgresql.Driver
+    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     {{- if .Values.backend.config.database.secret }}
     hibernate.connection.username: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret "Key" "database.username" ) -}}
     hibernate.connection.password: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret "Key" "database.password") -}}

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -56,15 +56,16 @@ data:
     FEED_RETENTION: {{ .Values.backend.config.FEED_RETENTION | default 30 | int }}
     {{- if and (.Values.backend.config.database) (not .Values.postgresql.enabled) }}
     hibernate.connection.url: {{.Values.backend.config.database.connection_url }}
+    {{- if and (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
+    hibernate.connection.driver_class: org.postgresql.Driver
+    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+    {{ end }}
     {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect) (not .Values.postgresql.enabled)}}
     hibernate.connection.driver_class: {{.Values.backend.config.database.driver_class }}
     hibernate.dialect: {{.Values.backend.config.database.dialect }}
     hibernate.connection.username: {{.Values.backend.config.database.username }}
     hibernate.connection.password: {{.Values.backend.config.database.password }}
     {{ end }}
-    {{- else if and (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
-    hibernate.connection.driver_class: org.postgresql.Driver
-    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     {{- if .Values.backend.config.database.secret }}
     hibernate.connection.username: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret "Key" "database.username" ) -}}
     hibernate.connection.password: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret "Key" "database.password") -}}

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -53,7 +53,7 @@ data:
     {{ end }}
     COMPROMISED_PASSWORD_CHECK: {{ .Values.backend.config.COMPROMISED_PASSWORD_CHECK | default true }}
     DISABLE_REGISTRATION: {{ .Values.backend.config.DISABLE_REGISTRATION |  default false }}
-    FEED_RETENTION: {{ .Values.backend.config.FEED_RETENTION | int | default 30 }}
+    FEED_RETENTION: {{ .Values.backend.config.FEED_RETENTION | default 30 | int }}
     {{- if and (.Values.backend.config.database) (not .Values.postgresql.enabled) }}
     hibernate.connection.url: {{.Values.backend.config.database.connection_url }}
     {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect) (not .Values.postgresql.enabled)}}
@@ -62,7 +62,7 @@ data:
     hibernate.connection.username: {{.Values.backend.config.database.username }}
     hibernate.connection.password: {{.Values.backend.config.database.password }}
     {{ end }}
-    {{- else if (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
+    {{- else if and (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
     hibernate.connection.driver_class: org.postgresql.Driver
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     {{- if .Values.backend.config.database.secret }}

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -53,14 +53,15 @@ data:
     {{ end }}
     COMPROMISED_PASSWORD_CHECK: {{ .Values.backend.config.COMPROMISED_PASSWORD_CHECK | default true }}
     DISABLE_REGISTRATION: {{ .Values.backend.config.DISABLE_REGISTRATION |  default false }}
-    FEED_RETENTION: {{ .Values.backend.config.DISABLE_REGISTRATION | int | default 30 }}
+    FEED_RETENTION: {{ .Values.backend.config.FEED_RETENTION | int | default 30 }}
     {{- if and (.Values.backend.config.database) (not .Values.postgresql.enabled) }}
     hibernate.connection.url: {{.Values.backend.config.database.connection_url }}
-    {{- else if and (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect)}}
+    {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect) (not .Values.postgresql.enabled)}}
     hibernate.connection.driver_class: {{.Values.backend.config.database.driver_class }}
     hibernate.dialect: {{.Values.backend.config.database.dialect }}
     hibernate.connection.username: {{.Values.backend.config.database.username }}
     hibernate.connection.password: {{.Values.backend.config.database.password }}
+    {{ end }}
     {{- else if (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
     hibernate.connection.driver_class: org.postgresql.Driver
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/charts/apps/piped/templates/backend/deployment.yaml
+++ b/charts/apps/piped/templates/backend/deployment.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.backend.enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/apps/piped/templates/backend/ingress.yaml
+++ b/charts/apps/piped/templates/backend/ingress.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.ingress.backend.enabled }}
   {{- $fullName := include "common.names.fullname" . -}}
   {{- $ingressName := $fullName -}}
@@ -17,7 +16,6 @@
   {{- $primaryService := .Values.backend.service.main -}}
   {{- $defaultServiceName := "piped-backend" -}}
   {{- $defaultServicePort := get $primaryService.ports (include "bjw-s.common.lib.service.primaryPort" (dict "values" $primaryService)) -}}
-  ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/apps/piped/templates/common.yaml
+++ b/charts/apps/piped/templates/common.yaml
@@ -1,4 +1,3 @@
----
 {{- include "bjw-s.common.values.init" . }}
 
 {{- define "common.getValueFromSecret" }}

--- a/charts/apps/piped/templates/frontend/deployment.yaml
+++ b/charts/apps/piped/templates/frontend/deployment.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.frontend.enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/apps/piped/templates/frontend/ingress.yaml
+++ b/charts/apps/piped/templates/frontend/ingress.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.ingress.main.enabled }}
   {{- $fullName := include "common.names.fullname" . -}}
   {{- $ingressName := $fullName -}}
@@ -17,7 +16,6 @@
   {{- $primaryService := .Values.frontend.service.main -}}
   {{- $defaultServiceName := "piped-frontend" -}}
   {{- $defaultServicePort := get $primaryService.ports (include "bjw-s.common.lib.service.primaryPort" (dict "values" $primaryService)) -}}
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/apps/piped/templates/ytproxy/deployment.yaml
+++ b/charts/apps/piped/templates/ytproxy/deployment.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.ytproxy.enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/apps/piped/templates/ytproxy/ingress.yaml
+++ b/charts/apps/piped/templates/ytproxy/ingress.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.ingress.ytproxy.enabled }}
   {{- $fullName := include "common.names.fullname" . -}}
   {{- $ingressName := $fullName -}}
@@ -17,7 +16,6 @@
   {{- $primaryService := .Values.ytproxy.service.main -}}
   {{- $defaultServiceName := "piped-ytproxy" -}}
   {{- $defaultServicePort := get $primaryService.ports (include "bjw-s.common.lib.service.primaryPort" (dict "values" $primaryService)) -}}
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
It shouldn't require dialect and driver_class and instead default to using them but allow customization.