### PR TITLE
Allow overriding of secret keys for database

### DIFF
--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/TeamPiped/piped-proxy
 keywords:
   - streaming
-version: 4.1.2
+version: 5.0.0
 appVersion: latest
 kubeVersion: ">=1.22.0-0"
 maintainers:
@@ -28,4 +28,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `postgresql` chart dependency to version 13.2.27
+      description: Change database values configuration to allow overriding of secret keys for database

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -65,9 +65,9 @@ data:
     hibernate.connection.username: {{.Values.backend.config.database.username }}
     hibernate.connection.password: {{.Values.backend.config.database.password }}
     {{ end }}
-    {{- if .Values.backend.config.database.secret }}
-    hibernate.connection.username: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret "Key" "DB_USERNAME" ) }}
-    hibernate.connection.password: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret "Key" "DB_PASSWORD") }}
+    {{- if and (.Values.backend.config.database.secret) (.Values.backend.config.database.secret.name) }}
+    hibernate.connection.username: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.username | default "DB_USERNAME")) }}
+    hibernate.connection.password: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.password | default "DB_PASSWORD")) }}
     {{- end }}
     {{- else if .Values.postgresql.enabled }}
     hibernate.connection.url: jdbc:postgresql://piped-postgresql/{{ .Values.postgresql.auth.database}}

--- a/charts/apps/piped/values.yaml
+++ b/charts/apps/piped/values.yaml
@@ -99,7 +99,11 @@ backend:
     # password: changeme
     # Please only provide the secret name (it should already exist),
     # it should only include database.username and database.password as others will be taken from above.
-    # secret: secret-name
+    # secret:
+    #   name: secret-name
+    #   Optionally grab differently named keys
+    #   username: DB_USERNAME
+    #   password: DB_PASSWORD
 
 
   image:


### PR DESCRIPTION
I currently use the the [CrunchyData Postgres Operator](https://github.com/CrunchyData/postgres-operator) in my cluster, which provisions secrets for PostgreSQL users with the username and password. These contain keys that cannot be modified (from what I can tell), so this change allows the value to be overridden.

Before:

```yaml
secret: postgres-connection-details
```

After:

```yaml
secret:
  name: postgres-connection-details
  username: user
  password: pass
```