### PR TITLE
Update Piped-Proxy

### DIFF
--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/TeamPiped/piped-proxy
 keywords:
   - streaming
-version: 7.2.1
+version: 7.2.2
 appVersion: latest
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -28,4 +28,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Upgraded `piped-frontend` to current release.
+      description: Upgraded `piped-proxy` to current release.

--- a/charts/apps/piped/values.yaml
+++ b/charts/apps/piped/values.yaml
@@ -111,7 +111,7 @@ backend:
     repository: 1337kavin/piped
     # -- image tag
     # @chart.appVersion
-    tag: "latest@sha256:759979280703ba11e4069405d21c2fed62a902d135fcea25d76fa13a12f278d7"  # Manifest index /Index Digest
+    tag: "latest@sha256:759979280703ba11e4069405d21c2fed62a902d135fcea25d76fa13a12f278d7"  # Manifest index / Index Digest
     # -- image pull policy
     pullPolicy: IfNotPresent
 

--- a/charts/apps/piped/values.yaml
+++ b/charts/apps/piped/values.yaml
@@ -35,7 +35,7 @@ frontend:
     # -- image repository
     repository: 1337kavin/piped-frontend
     # -- image tag
-    tag: "latest@sha256:95d42ad855681cc8abcc12f95687b1508f71dcb635eaf2ead4335ae43b851269"  # Manifest index
+    tag: "latest@sha256:95d42ad855681cc8abcc12f95687b1508f71dcb635eaf2ead4335ae43b851269"  # Manifest index / Index Digest
     # -- image pull policy
     pullPolicy: IfNotPresent
 
@@ -111,7 +111,7 @@ backend:
     repository: 1337kavin/piped
     # -- image tag
     # @chart.appVersion
-    tag: "latest@sha256:759979280703ba11e4069405d21c2fed62a902d135fcea25d76fa13a12f278d7"  # Manifest index
+    tag: "latest@sha256:759979280703ba11e4069405d21c2fed62a902d135fcea25d76fa13a12f278d7"  # Manifest index /Index Digest
     # -- image pull policy
     pullPolicy: IfNotPresent
 
@@ -142,7 +142,7 @@ ytproxy:
     # -- image repository
     repository: 1337kavin/piped-proxy
     # -- image tag
-    tag: "latest@sha256:4a77a613b33d8e8628463044a070a2c6ac353a5d8963f4abc1efccf00754ce09"  # Manifest index
+    tag: "latest@sha256:880b1117b6087e32b82c0204a96210fb87de61a874a3a2681361cc6d905e4d0e"  # Manifest index / Index Digest
     # -- image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Update Piped-Proxy with the Index Digest to: `sha256:880b1117b6087e32b82c0204a96210fb87de61a874a3a2681361cc6d905e4d0e`




REF:

- https://hub.docker.com/layers/1337kavin/piped-proxy/latest/images/sha256-630d1e83c655ef7e88c5121c3808969be3c54f2bf0fbe9fd04865a2c008bedd4