### PR TITLE
Remove nil postgres references from backend configmap template

### DIFF
--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -69,13 +69,13 @@ data:
     COMPROMISED_PASSWORD_CHECK: {{ .Values.backend.config.COMPROMISED_PASSWORD_CHECK | default true }}
     DISABLE_REGISTRATION: {{ .Values.backend.config.DISABLE_REGISTRATION |  default false }}
     FEED_RETENTION: {{ .Values.backend.config.FEED_RETENTION | default 30 | int }}
-    {{- if and (.Values.backend.config.database) (not .Values.postgresql.enabled) }}
+    {{- if .Values.backend.config.database }}
     hibernate.connection.url: {{.Values.backend.config.database.connection_url }}
     {{- if and (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
     hibernate.connection.driver_class: org.postgresql.Driver
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     {{ end }}
-    {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect) (not .Values.postgresql.enabled)}}
+    {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect)}}
     hibernate.connection.driver_class: {{.Values.backend.config.database.driver_class }}
     hibernate.dialect: {{.Values.backend.config.database.dialect }}
     hibernate.connection.username: {{.Values.backend.config.database.username }}


### PR DESCRIPTION
80a97f91a822667b1890af63f6d9913befedec37 removed the postgres sub-chart and related values, but did not remove all references to the now-deleted values in templates, causing errors in evaluation.