### PR TITLE
fix: resolving the correct username and password from existing database secret

### DIFF
--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/TeamPiped/Piped-Kubernetes
 keywords:
   - streaming
-version: 8.1.16
+version: 8.1.17
 appVersion: latest
 kubeVersion: ">=1.29.0"
 maintainers:

--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -25,4 +25,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Updated image for `ytproxy` from latest@sha256:d21fe31af54ecc136b20405c756f6c7ae2c437376204ab099dbe930fcafff8c9 to latest@sha256:d3b953c4d15097d5b2cb79033203cc1a6e030c0220cbe5c40ab938ea9ac444d8
+      description: Change ConfigMap templating to render the keys from an existing secret if this option is enabled. This was broken, which resulted in empty config files in the configuration.properties file, which caused the backend to fail to start.

--- a/charts/apps/piped/Chart.yaml
+++ b/charts/apps/piped/Chart.yaml
@@ -25,4 +25,4 @@ dependencies:
 annotations:
   artifacthub.io/changes: |-
     - kind: changed
-      description: Change ConfigMap templating to render the keys from an existing secret if this option is enabled. This was broken, which resulted in empty config files in the configuration.properties file, which caused the backend to fail to start.
+      description: Change ConfigMap templating to render the keys from an existing secret if this option is enabled. This was broken, which resulted in empty config keys in the configuration.properties file, which caused the backend to fail to start.

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -73,21 +73,20 @@ data:
     hibernate.connection.url: {{.Values.backend.config.database.connection_url }}
     {{- $dbUsername := (.Values.backend.config.database.username | default "") }}
     {{- $dbPassword := (.Values.backend.config.database.password | default "") }}
-    {{- if and (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
-    hibernate.connection.driver_class: org.postgresql.Driver
-    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
-    {{ end }}
-    {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect) }}
-    hibernate.connection.driver_class: {{.Values.backend.config.database.driver_class }}
-    hibernate.dialect: {{.Values.backend.config.database.dialect }}
-    {{ end }}
+    hibernate.connection.driver_class: {{ .Values.backend.config.database.driver_class | default "org.postgresql.Driver" }}
+    hibernate.dialect: {{ .Values.backend.config.database.dialect | default "org.hibernate.dialect.PostgreSQLDialect" }}
     {{- if and (.Values.backend.config.database.secret) (.Values.backend.config.database.secret.name) }}
     {{- $dbSecretNamespace := (.Values.backend.config.database.secret.namespace | default .Release.Namespace) }}
-    {{- $dbSecretUsername := (include "common.getValueFromSecret" (dict "Namespace" $dbSecretNamespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.username | default "DB_USERNAME")) | trim) }}
-    {{- $dbSecretPassword := (include "common.getValueFromSecret" (dict "Namespace" $dbSecretNamespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.password | default "DB_PASSWORD")) | trim) }}
-    {{- if and $dbSecretUsername $dbSecretPassword -}}
+    {{- $dbSecretUsernameKey := (.Values.backend.config.database.secret.username | default "DB_USERNAME") }}
+    {{- $dbSecretPasswordKey := (.Values.backend.config.database.secret.password | default "DB_PASSWORD") }}
+    {{- $dbSecretData := (lookup "v1" "Secret" $dbSecretNamespace .Values.backend.config.database.secret.name).data }}
+    {{- if and $dbSecretData (hasKey $dbSecretData $dbSecretUsernameKey) (hasKey $dbSecretData $dbSecretPasswordKey) -}}
+      {{- $dbSecretUsername := (include "common.getValueFromSecret" (dict "Namespace" $dbSecretNamespace "Name" .Values.backend.config.database.secret.name "Key" $dbSecretUsernameKey)) -}}
+      {{- $dbSecretPassword := (include "common.getValueFromSecret" (dict "Namespace" $dbSecretNamespace "Name" .Values.backend.config.database.secret.name "Key" $dbSecretPasswordKey)) -}}
       {{- $dbUsername = $dbSecretUsername -}}
       {{- $dbPassword = $dbSecretPassword -}}
+    {{- else if and $dbSecretData (or (hasKey $dbSecretData $dbSecretUsernameKey) (hasKey $dbSecretData $dbSecretPasswordKey)) -}}
+      {{- fail (printf "Database secret %q in namespace %q is missing required keys %q and/or %q" .Values.backend.config.database.secret.name $dbSecretNamespace $dbSecretUsernameKey $dbSecretPasswordKey) -}}
     {{- end -}}
     {{- end }}
     {{- if and $dbUsername $dbPassword }}

--- a/charts/apps/piped/templates/backend/configmap.yaml
+++ b/charts/apps/piped/templates/backend/configmap.yaml
@@ -71,19 +71,30 @@ data:
     FEED_RETENTION: {{ .Values.backend.config.FEED_RETENTION | default 30 | int }}
     {{- if .Values.backend.config.database }}
     hibernate.connection.url: {{.Values.backend.config.database.connection_url }}
+    {{- $dbUsername := (.Values.backend.config.database.username | default "") }}
+    {{- $dbPassword := (.Values.backend.config.database.password | default "") }}
     {{- if and (not .Values.backend.config.database.driver_class) (not .Values.backend.config.database.dialect) }}
     hibernate.connection.driver_class: org.postgresql.Driver
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     {{ end }}
-    {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect)}}
+    {{- if and (.Values.backend.config.database) (.Values.backend.config.database.driver_class) (.Values.backend.config.database.dialect) }}
     hibernate.connection.driver_class: {{.Values.backend.config.database.driver_class }}
     hibernate.dialect: {{.Values.backend.config.database.dialect }}
-    hibernate.connection.username: {{.Values.backend.config.database.username }}
-    hibernate.connection.password: {{.Values.backend.config.database.password }}
     {{ end }}
     {{- if and (.Values.backend.config.database.secret) (.Values.backend.config.database.secret.name) }}
-    hibernate.connection.username: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.username | default "DB_USERNAME")) }}
-    hibernate.connection.password: {{ include "common.getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.password | default "DB_PASSWORD")) }}
+    {{- $dbSecretNamespace := (.Values.backend.config.database.secret.namespace | default .Release.Namespace) }}
+    {{- $dbSecretUsername := (include "common.getValueFromSecret" (dict "Namespace" $dbSecretNamespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.username | default "DB_USERNAME")) | trim) }}
+    {{- $dbSecretPassword := (include "common.getValueFromSecret" (dict "Namespace" $dbSecretNamespace "Name" .Values.backend.config.database.secret.name "Key" (.Values.backend.config.database.secret.password | default "DB_PASSWORD")) | trim) }}
+    {{- if and $dbSecretUsername $dbSecretPassword -}}
+      {{- $dbUsername = $dbSecretUsername -}}
+      {{- $dbPassword = $dbSecretPassword -}}
+    {{- end -}}
+    {{- end }}
+    {{- if and $dbUsername $dbPassword }}
+    hibernate.connection.username: {{ $dbUsername }}
+    hibernate.connection.password: {{ $dbPassword }}
+    {{- else }}
+    {{- fail "Unable to construct database credentials. Either set backend.config.database.username/password (works offline with helm template), or configure backend.config.database.secret and run with cluster access so lookup can resolve it." }}
     {{- end }}
     {{- else }}
      {{ fail "Unable to construct database configuration. Set backend.config.database.connection_url, driver_class, dialect, username and password, or configure backend.config.database.secret.{name,username,password} to point at an existing Secret. This chart does not deploy a database; it must point to an external one." }}


### PR DESCRIPTION
This commits fixes issue #259. It now resolves the username and password from a existing secret correctly.

Fixed #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database credentials can now be sourced from Kubernetes Secrets with configurable namespace resolution for safer, more flexible configuration.

* **Bug Fixes**
  * Deployments now validate presence of required credential keys and fail early if credentials are incomplete, preventing startup with empty config.

* **Chores**
  * Helm chart version bumped to 8.1.17
<!-- end of auto-generated comment: release notes by coderabbit.ai -->